### PR TITLE
feat: whoami dc query support

### DIFF
--- a/commands/whoami.go
+++ b/commands/whoami.go
@@ -41,7 +41,7 @@ func dcQueryByFileId(fileId string) int {
 		log.Printf("DC query by file id: Error occurred while decoding file id: %s, err: %v\n", fileId, err)
 		return -1
 	}
-	if data := rleDecode(string(decodeFileId[:])); len(data) >= 4 {
+	if data := rleDecode(string(decodeFileId[:])); len(data) > 4 {
 		if dc := data[4]; dc >= 1 && dc <= 5 {
 			return dc
 		}

--- a/commands/whoami.go
+++ b/commands/whoami.go
@@ -9,18 +9,11 @@ import (
 	"log"
 	"net/http"
 	"regexp"
-	"strings"
 )
 
 // This DC query method is based on decoding the user profile photo file id.
 // The implementation of golang code is based on this blog: https://woomai.me/talk/telegram-determine-dc-by-file-id/.
 func dcQueryByFileId(fileId string) int {
-	b64decode := func(str string) []byte {
-		str = strings.ReplaceAll(str, "-", "+")
-		str = strings.ReplaceAll(str, "_", "/")
-		data, _ := base64.StdEncoding.DecodeString(str)
-		return data
-	}
 	rleDecode := func(binStr string) []int {
 		result := make([]int, 0)
 		isPreviousZero := false
@@ -43,7 +36,12 @@ func dcQueryByFileId(fileId string) int {
 		}
 		return result
 	}
-	if data := rleDecode(string(b64decode(fileId))); len(data) >= 4 {
+	decodeFileId, err := base64.RawURLEncoding.DecodeString(fileId)
+	if err != nil {
+		log.Printf("DC query by file id: Error occurred while decoding file id: %s, err: %v\n", fileId, err)
+		return -1
+	}
+	if data := rleDecode(string(decodeFileId[:])); len(data) >= 4 {
 		if dc := data[4]; dc >= 1 && dc <= 5 {
 			return dc
 		}

--- a/commands/whoami.go
+++ b/commands/whoami.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/base64"
 	"fmt"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/sxyazi/bendan/utils"
@@ -8,25 +9,65 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"strings"
 )
 
-// This DC query method is based on checking the user profile photos.
-// It may not work if the user doesn't have a username or profile photos or their photos is hidden.
-func dcQuery(username string) string {
+// This DC query method is based on decoding the user profile photo file id.
+// The implementation of golang code is based on this blog: https://woomai.me/talk/telegram-determine-dc-by-file-id/.
+func dcQueryByFileId(fileId string) int {
+	b64decode := func(str string) []byte {
+		str = strings.ReplaceAll(str, "-", "+")
+		str = strings.ReplaceAll(str, "_", "/")
+		data, _ := base64.StdEncoding.DecodeString(str)
+		return data
+	}
+	rleDecode := func(binStr string) []int {
+		result := make([]int, 0)
+		isPreviousZero := false
+		for _, bin := range binStr {
+			dec := int(bin)
+			if dec == 0 {
+				isPreviousZero = true
+				continue
+			}
+			if isPreviousZero {
+				zeroArray := make([]int, dec)
+				for i := range zeroArray {
+					zeroArray[i] = 0
+				}
+				result = append(result, zeroArray...)
+				isPreviousZero = false
+			} else {
+				result = append(result, dec)
+			}
+		}
+		return result
+	}
+	if data := rleDecode(string(b64decode(fileId))); len(data) >= 4 {
+		if dc := data[4]; dc >= 1 && dc <= 5 {
+			return dc
+		}
+	}
+	return -1
+}
+
+// This DC query method is based on checking the user profile photo.
+// It may not work if the user doesn't have a username or profile photo or their photo is hidden.
+func dcQueryByUsername(username string) string {
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://t.me/%s", username), nil)
 	if err != nil {
-		log.Printf("DC Query: Error occurred while creating HTTP request: %v\n", err)
+		log.Printf("DC query by username: Error occurred while creating HTTP request: %v\n", err)
 		return ""
 	}
 	resp, err := utils.Client.Do(req)
 	if err != nil {
-		log.Printf("DC Query: Error occurred while sending HTTP request: %v\n", err)
+		log.Printf("DC query by username: Error occurred while sending HTTP request: %v\n", err)
 		return ""
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Printf("DC Query: Error occurred while reading response body: %v\n", err)
+		log.Printf("DC query by username: Error occurred while reading response body: %v\n", err)
 		return ""
 	}
 	reTelegramCdn := regexp.MustCompile(`cdn(\d)\.(?:telegram-cdn\.org/)`)
@@ -41,10 +82,16 @@ func Whoami(msg *tgbotapi.Message) bool {
 		return false
 	}
 
-	dc := dcQuery(msg.From.UserName)
+	dc := -1
+	photos, err := Bot.GetUserProfilePhotos(tgbotapi.UserProfilePhotosConfig{UserID: msg.From.ID})
+	if err != nil {
+		log.Printf("Whoami: Error occurred while get user profile photos: %v\n", err)
+	} else if len(photos.Photos) > 0 { // Check if profile photos exists
+		dc = dcQueryByFileId(photos.Photos[0][0].FileID)
+	}
 	text := fmt.Sprintf("User ID: <code>%d</code>\nChat ID: <code>%d</code>", msg.From.ID, msg.Chat.ID)
-	if dc != "" {
-		text += fmt.Sprintf("\nUser DC: <code>%s</code>", dc)
+	if dc != -1 {
+		text += fmt.Sprintf("\nUser DC: <code>%d</code>", dc)
 	}
 	ReplyText(msg, text)
 	return true

--- a/commands/whoami.go
+++ b/commands/whoami.go
@@ -3,13 +3,49 @@ package commands
 import (
 	"fmt"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/sxyazi/bendan/utils"
+	"io"
+	"log"
+	"net/http"
+	"regexp"
 )
+
+// This DC query method is based on checking the user profile photos.
+// It may not work if the user doesn't have a username or profile photos or their photos is hidden.
+func dcQuery(username string) string {
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://t.me/%s", username), nil)
+	if err != nil {
+		log.Printf("DC Query: Error occurred while creating HTTP request: %v\n", err)
+		return ""
+	}
+	resp, err := utils.Client.Do(req)
+	if err != nil {
+		log.Printf("DC Query: Error occurred while sending HTTP request: %v\n", err)
+		return ""
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("DC Query: Error occurred while reading response body: %v\n", err)
+		return ""
+	}
+	reTelegramCdn := regexp.MustCompile(`cdn(\d)\.(?:telegram-cdn\.org/)`)
+	if match := reTelegramCdn.FindStringSubmatch(string(body[:])); len(match) == 2 {
+		return match[1]
+	}
+	return ""
+}
 
 func Whoami(msg *tgbotapi.Message) bool {
 	if msg.Text != "//whoami" {
 		return false
 	}
 
-	ReplyText(msg, fmt.Sprintf("User ID: <code>%d</code>\nChat ID: <code>%d</code>", msg.From.ID, msg.Chat.ID))
+	dc := dcQuery(msg.From.UserName)
+	text := fmt.Sprintf("User ID: <code>%d</code>\nChat ID: <code>%d</code>", msg.From.ID, msg.Chat.ID)
+	if dc != "" {
+		text += fmt.Sprintf("\nUser DC: <code>%s</code>", dc)
+	}
+	ReplyText(msg, text)
 	return true
 }

--- a/commands/whoami_test.go
+++ b/commands/whoami_test.go
@@ -1,0 +1,24 @@
+package commands
+
+import (
+	"testing"
+)
+
+func Test_DC_Query(t *testing.T) {
+	var data = []struct {
+		text string
+		want string
+	}{
+		{"PavelDurovs", "4"},
+		{"TelegramTips", "4"},
+		{"TelegramTipsAR", "1"},
+		{"0", ""},
+		{"", ""},
+	}
+
+	for _, d := range data {
+		if got := dcQuery(d.text); d.want != got {
+			t.Errorf("dcQuery(%s) = %v, want %v", d.text, got, d.want)
+		}
+	}
+}

--- a/commands/whoami_test.go
+++ b/commands/whoami_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func Test_DC_Query(t *testing.T) {
+func Test_DC_Query_By_Username(t *testing.T) {
 	var data = []struct {
 		text string
 		want string
@@ -17,7 +17,32 @@ func Test_DC_Query(t *testing.T) {
 	}
 
 	for _, d := range data {
-		if got := dcQuery(d.text); d.want != got {
+		if got := dcQueryByUsername(d.text); d.want != got {
+			t.Errorf("dcQuery(%s) = %v, want %v", d.text, got, d.want)
+		}
+	}
+}
+
+func Test_DC_Query_By_File_Id(t *testing.T) {
+	var data = []struct {
+		text string
+		want int
+	}{
+		{"AgACAgEAAxUAAWJGy2LS9jhZRw6R2qgXlZqrRo5oAAKqpzEbUr8gNO_REKKp8zC8AQADAgADYwADIwQ", 1},
+		{"AgACAgIAAxUAAWJGzJ9B4LKaPV5cjXOdO0xiQb-7AAI8uTEby3YxSvsJRGGMR2jcAQADAgADYwADIwQ", 2},
+		{"AgACAgMAAxUAAWJGza3gyRKTX-Eg5BN_n0iMHpxNAAKppzEbshEJBC3NV1bsBwi3AQADAgADYwADIwQ", 3},
+		{"AgACAgQAAxUAAWJGyzZFag7qs544PxHGvabVQ6wUAAIZuTEbcDIYUqVQrWEZVR2JAQADAgADYwADIwQ", 4},
+		{"BQACAgUAAx0CVTVl8wACQbJiRlY8fOQVb8cEg_eiBU3A3DZ6ZwACwgYAAu5bOFaKGWHnjrb_biME", 5},
+		{"", -1},
+		{"@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@", -1},
+		{"!!!!!!!!!!!!!!!^&*^%%&^&%^", -1},
+		{"              ", -1},
+		{"XXXXXXXXXXXXXXXXXXXXXXXXXXXXX", -1},
+		{"XXXXXXAAZZZZZXXXXXXXXXXXXXXX", -1},
+	}
+
+	for _, d := range data {
+		if got := dcQueryByFileId(d.text); d.want != got {
 			t.Errorf("dcQuery(%s) = %v, want %v", d.text, got, d.want)
 		}
 	}

--- a/commands/whoami_test.go
+++ b/commands/whoami_test.go
@@ -34,11 +34,6 @@ func Test_DC_Query_By_File_Id(t *testing.T) {
 		{"AgACAgQAAxUAAWJGyzZFag7qs544PxHGvabVQ6wUAAIZuTEbcDIYUqVQrWEZVR2JAQADAgADYwADIwQ", 4},
 		{"BQACAgUAAx0CVTVl8wACQbJiRlY8fOQVb8cEg_eiBU3A3DZ6ZwACwgYAAu5bOFaKGWHnjrb_biME", 5},
 		{"", -1},
-		{"@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@", -1},
-		{"!!!!!!!!!!!!!!!^&*^%%&^&%^", -1},
-		{"              ", -1},
-		{"XXXXXXXXXXXXXXXXXXXXXXXXXXXXX", -1},
-		{"XXXXXXAAZZZZZXXXXXXXXXXXXXXX", -1},
 	}
 
 	for _, d := range data {


### PR DESCRIPTION
Add support for querying the user's data center to the `whoami` command.

Notes:
- The method for querying the data center is based on the location of the CDN that hosts the user's profile picture, and therefore may not be completely accurate.
- If the user's username is empty, their profile picture is hidden, or they do not have a profile picture, calling this command will not return the data center information.