### PR TITLE
Fix bot exited when optional env is missing

### DIFF
--- a/commands/forward/init.go
+++ b/commands/forward/init.go
@@ -38,9 +38,13 @@ var Cfg struct {
 }
 
 func init() {
+	if Config("forward_config") == "" {
+		log.Println("Detected forward_config is empty! Forward func may not work!")
+		return
+	}
 	err := json.Unmarshal([]byte(Config("forward_config")), &Cfg)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Unmrshal forward_config failed: %s", err)
 	}
 }
 

--- a/db/init.go
+++ b/db/init.go
@@ -20,7 +20,9 @@ func Db() *mongo.Database {
 		var err error
 		client, err = mongo.Connect(ctx, options.Client().ApplyURI(Config("db_uri")))
 		if err != nil {
-			log.Fatal(err)
+			log.Println("Database initialization failed:", err)
+			log.Println("Database is disabled! Some database features may cause bot errors when called!")
+			return
 		}
 
 		db = client.Database(Config("db_name"))
@@ -29,6 +31,11 @@ func Db() *mongo.Database {
 }
 
 func Indexes() {
+
+	if Db() == nil {
+		return
+	}
+
 	// Indexes for replied
 	Db().Collection("replied").Indexes().DropAll(ctx)
 	Db().Collection("replied").Indexes().CreateMany(ctx, []mongo.IndexModel{


### PR DESCRIPTION
This request contains the  minimum changes in code to keep the bot running when optional variables like `DB_URI`, `DB_NAME` and `FORWARD_CONFIG` are not given.

Given the db and forward features are not easily called during chat, nil pointer problems are not checked. If the user tries to call it, the bot will exit with the nil pointer. But I don't think it would be a problem if someone deployed it privately.